### PR TITLE
update editor content to not have html tags returned

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "singleQuote": false,
+  "singleQuote": true,
   "trailingComma": "none",
   "bracketSpacing": true,
   "tabWidth": 2,

--- a/src/class/CaptionManager.js
+++ b/src/class/CaptionManager.js
@@ -122,7 +122,7 @@ class CaptionManager {
   emit() {
     this.emitCurrent();
     this.emitData();
-    EventBus.$emit('file_selected', {file: this.file});
+    EventBus.$emit('file_selected', { file: this.file });
   }
 
   get lastIndex() {

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -52,8 +52,8 @@
 </template>
 
 <script>
-import TimeStampInput from "./TimeStampInput";
-import { EventBus } from "@/class/EventBus";
+import TimeStampInput from './TimeStampInput';
+import { EventBus } from '@/class/EventBus';
 export default {
   components: {
     TimeStampInput
@@ -61,26 +61,26 @@ export default {
   data() {
     return {
       index: 0,
-      content: "",
+      content: '',
       start: 0,
       end: 0,
       lastIndex: 0,
       canEmit: false,
       sizeOptions: [
-        { value: "10px", label: "Small", default: false },
-        { value: "16px", label: "Normal", default: true },
-        { value: "18px", label: "Large", default: false },
-        { value: "32px", label: "Huge", default: false }
+        { value: '10px', label: 'Small', default: false },
+        { value: '16px', label: 'Normal', default: true },
+        { value: '18px', label: 'Large', default: false },
+        { value: '32px', label: 'Huge', default: false }
       ],
       colorOptions: [
-        { value: "#000000", default: true },
-        { value: "#FFFFFF", default: false },
-        { value: "#FF0000", default: false },
-        { value: "#00FF00", default: false },
-        { value: "#0000FF", default: false },
-        { value: "#FFFF00", default: false },
-        { value: "#00FFFF", default: false },
-        { value: "#FF00FF", default: false }
+        { value: '#000000', default: true },
+        { value: '#FFFFFF', default: false },
+        { value: '#FF0000', default: false },
+        { value: '#00FF00', default: false },
+        { value: '#0000FF', default: false },
+        { value: '#FFFF00', default: false },
+        { value: '#00FFFF', default: false },
+        { value: '#FF00FF', default: false }
       ]
     };
   },
@@ -97,19 +97,19 @@ export default {
       if (!this.canEmit) {
         return;
       }
-      EventBus.$emit("caption_update", { content: $event.text.trim() }); //.trim() removes the `\n` newline that .text returns
+      EventBus.$emit('caption_update', { content: $event.text.trim() }); //.trim() removes the `\n` newline that .text returns
     },
     onStartTimeUpdated($event) {
       if (!this.canEmit) {
         return;
       }
-      EventBus.$emit("caption_update", { start: $event });
+      EventBus.$emit('caption_update', { start: $event });
     },
     onEndTimeUpdated($event) {
       if (!this.canEmit) {
         return;
       }
-      EventBus.$emit("caption_update", { end: $event });
+      EventBus.$emit('caption_update', { end: $event });
     },
     onUpdate($event) {
       const { content, start, end } = $event.data;
@@ -121,10 +121,10 @@ export default {
       this.canEmit = true;
     },
     addCaption() {
-      EventBus.$emit("caption_add_index");
+      EventBus.$emit('caption_add_index');
     },
     removeCaption() {
-      EventBus.$emit("caption_remove_index");
+      EventBus.$emit('caption_remove_index');
     },
     escapeString() {
       const isEscaped = /^{{.*}}$/;
@@ -134,7 +134,7 @@ export default {
       const baseString = selection.anchorNode.data;
       const text = baseString.slice(offset, endset).trim();
 
-      const parent = document.getElementById("quill-editor");
+      const parent = document.getElementById('quill-editor');
 
       if (
         !parent.contains(selection.anchorNode) ||
@@ -151,26 +151,26 @@ export default {
     },
     reset() {
       this.canEmit = false;
-      this.content = "";
+      this.content = '';
       this.start = this.end = 0;
     }
   },
 
   mounted() {
-    EventBus.$on("caption_changed", this.onUpdate);
-    EventBus.$on("caption_reset", this.reset);
+    EventBus.$on('caption_changed', this.onUpdate);
+    EventBus.$on('caption_reset', this.reset);
   },
   destroyed() {
-    EventBus.$off("caption_changed", this.onUpdate);
-    EventBus.$off("caption_reset", this.reset);
+    EventBus.$off('caption_changed', this.onUpdate);
+    EventBus.$off('caption_reset', this.reset);
   }
 };
 </script>
 
 <style lang="scss">
-@import "~@/scss/colors";
-@import "~@/scss/fonts";
-@import "~@/scss/sizes";
+@import '~@/scss/colors';
+@import '~@/scss/fonts';
+@import '~@/scss/sizes';
 .editor {
   $quill: 20rem;
   $controls: 10.8rem;

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -112,8 +112,7 @@ export default {
       EventBus.$emit('caption_update', { end: $event });
     },
     onUpdate($event) {
-      const { content, start, end } = $event.data;
-      this.content = content;
+      const { start, end } = $event.data;
       this.start = start;
       this.end = end;
       this.lastIndex = $event.lastIndex;

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="editor">
-    <quill-editor id="quill-editor" v-model=content @change="onEdit" class="editor__quill">
+    <quill-editor id="quill-editor" v-model="content" @change="onEdit" class="editor__quill">
       <div id="toolbar" slot="toolbar">
         <select class="ql-font">
           <option selected="selected"></option>
@@ -8,27 +8,52 @@
           <option value="monospace"></option>
         </select>
         <select class="ql-size">
-          <option v-for="size in sizeOptions" :key="size.value"  :value="size.value" :selected="size.default">{{size.label}}</option>
+          <option
+            v-for="size in sizeOptions"
+            :key="size.value"
+            :value="size.value"
+            :selected="size.default"
+          >{{size.label}}</option>
         </select>
         <select class="ql-color">
-          <option v-for="color in colorOptions" :key="color.value"  :value="color.value" :selected="color.default"/>
+          <option
+            v-for="color in colorOptions"
+            :key="color.value"
+            :value="color.value"
+            :selected="color.default"
+          />
         </select>
         <button class="ql-bold">Bold</button>
-        <button @click=escapeString class="editor__escape-button"><span v-pre>&#123;&#123; &#125;&#125;</span></button>
+        <button @click="escapeString" class="editor__escape-button">
+          <span v-pre>&#123;&#123; &#125;&#125;</span>
+        </button>
       </div>
     </quill-editor>
     <div class="editor__controls">
-      <TimeStampInput @time=onStartTimeUpdated :default=start name="start"/>
-      <TimeStampInput @time=onEndTimeUpdated :default=end name="end"/>
+      <TimeStampInput @time="onStartTimeUpdated" :default="start" name="start" />
+      <TimeStampInput @time="onEndTimeUpdated" :default="end" name="end" />
     </div>
-    <v-btn v-if=canRemove @click=removeCaption :block=true color="accent" class="editor__button font-16 font-semi-bold capitalize">Remove Caption</v-btn>
-    <v-btn v-else @click=addCaption :disabled=!canAdd :block=true color="accent" class="editor__button font-16 font-semi-bold capitalize">Add Caption</v-btn>
+    <v-btn
+      v-if="canRemove"
+      @click="removeCaption"
+      :block="true"
+      color="accent"
+      class="editor__button font-16 font-semi-bold capitalize"
+    >Remove Caption</v-btn>
+    <v-btn
+      v-else
+      @click="addCaption"
+      :disabled="!canAdd"
+      :block="true"
+      color="accent"
+      class="editor__button font-16 font-semi-bold capitalize"
+    >Add Caption</v-btn>
   </div>
 </template>
 
 <script>
-import TimeStampInput from './TimeStampInput';
-import { EventBus } from '@/class/EventBus';
+import TimeStampInput from "./TimeStampInput";
+import { EventBus } from "@/class/EventBus";
 export default {
   components: {
     TimeStampInput
@@ -36,26 +61,26 @@ export default {
   data() {
     return {
       index: 0,
-      content: '',
+      content: "",
       start: 0,
       end: 0,
       lastIndex: 0,
       canEmit: false,
       sizeOptions: [
-        { value: '10px', label: 'Small',  default: false},
-        { value: '16px', label: 'Normal', default: true},
-        { value: '18px', label: 'Large', default: false},
-        { value: '32px', label: 'Huge', default: false}
+        { value: "10px", label: "Small", default: false },
+        { value: "16px", label: "Normal", default: true },
+        { value: "18px", label: "Large", default: false },
+        { value: "32px", label: "Huge", default: false }
       ],
       colorOptions: [
-        {value: '#000000', default: true },
-        {value: '#FFFFFF', default: false },
-        {value: '#FF0000', default: false },
-        {value: '#00FF00', default: false },
-        {value: '#0000FF', default: false },
-        {value: '#FFFF00', default: false },
-        {value: '#00FFFF', default: false },
-        {value: '#FF00FF', default: false },
+        { value: "#000000", default: true },
+        { value: "#FFFFFF", default: false },
+        { value: "#FF0000", default: false },
+        { value: "#00FF00", default: false },
+        { value: "#0000FF", default: false },
+        { value: "#FFFF00", default: false },
+        { value: "#00FFFF", default: false },
+        { value: "#FF00FF", default: false }
       ]
     };
   },
@@ -72,22 +97,22 @@ export default {
       if (!this.canEmit) {
         return;
       }
-      EventBus.$emit('caption_update', {content: $event.html });
+      EventBus.$emit("caption_update", { content: $event.text.trim() }); //.trim() removes the `\n` newline that .text returns
     },
     onStartTimeUpdated($event) {
       if (!this.canEmit) {
         return;
       }
-      EventBus.$emit('caption_update', { start: $event });
+      EventBus.$emit("caption_update", { start: $event });
     },
     onEndTimeUpdated($event) {
       if (!this.canEmit) {
         return;
       }
-      EventBus.$emit('caption_update', { end: $event });
+      EventBus.$emit("caption_update", { end: $event });
     },
     onUpdate($event) {
-      const {content, start, end} = $event.data;
+      const { content, start, end } = $event.data;
       this.content = content;
       this.start = start;
       this.end = end;
@@ -96,10 +121,10 @@ export default {
       this.canEmit = true;
     },
     addCaption() {
-      EventBus.$emit('caption_add_index');
+      EventBus.$emit("caption_add_index");
     },
     removeCaption() {
-      EventBus.$emit('caption_remove_index');
+      EventBus.$emit("caption_remove_index");
     },
     escapeString() {
       const isEscaped = /^{{.*}}$/;
@@ -109,28 +134,35 @@ export default {
       const baseString = selection.anchorNode.data;
       const text = baseString.slice(offset, endset).trim();
 
-      const parent = document.getElementById('quill-editor');
+      const parent = document.getElementById("quill-editor");
 
-      if (!parent.contains(selection.anchorNode) || isEscaped.test(text) || !text.trim()) {
+      if (
+        !parent.contains(selection.anchorNode) ||
+        isEscaped.test(text) ||
+        !text.trim()
+      ) {
         return;
       }
 
-      selection.anchorNode.data = baseString.substring(0, offset) + `{{${text}}}` + baseString.substring(endset, baseString.length);
+      selection.anchorNode.data =
+        baseString.substring(0, offset) +
+        `{{${text}}}` +
+        baseString.substring(endset, baseString.length);
     },
     reset() {
       this.canEmit = false;
-      this.content = '';
+      this.content = "";
       this.start = this.end = 0;
     }
   },
 
   mounted() {
-    EventBus.$on('caption_changed', this.onUpdate);
-    EventBus.$on('caption_reset', this.reset);
+    EventBus.$on("caption_changed", this.onUpdate);
+    EventBus.$on("caption_reset", this.reset);
   },
   destroyed() {
-    EventBus.$off('caption_changed', this.onUpdate);
-    EventBus.$off('caption_reset', this.reset);
+    EventBus.$off("caption_changed", this.onUpdate);
+    EventBus.$off("caption_reset", this.reset);
   }
 };
 </script>


### PR DESCRIPTION
The `$event.htm`l at line 75 was returning the editor text with the appropriate HTML tags. Switched it over to `$event.text` which returns just text with a newline and added `.trim()` to strip that off. 