### PR TITLE
Feature/187839053 - Game Demo Mute

### DIFF
--- a/src/components/GameDemo/index.tsx
+++ b/src/components/GameDemo/index.tsx
@@ -1,8 +1,9 @@
 import { useEffect, JSX } from 'react';
 import clsx from 'clsx';
 import styles from './styles.module.scss';
-import { Container } from 'springroll-container';
+import { Container, SoundPlugin } from 'springroll-container';
 import Heading from '@theme/Heading';
+
 
 /**
  * Game Demo Component - Creates a springroll container and loads the demo game into it. Referenced in docs/Examples/game.mdx
@@ -12,7 +13,11 @@ export default function GameDemo(): JSX.Element {
   // Instantiate the container and load the demo game after the component mounts  
   useEffect(() => {
     const container = new Container('#demo-game', {
-      plugins: []
+      plugins: [
+        new SoundPlugin({
+          soundButtons: '#btnMute',
+        })
+      ]
     });
 
     container.openPath('http://springroll.io/springroll-io-demo-game/');
@@ -26,13 +31,14 @@ export default function GameDemo(): JSX.Element {
           Game Options
         </Heading>
         
-        <button type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
+        <button id="btnPause" type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
           <span>Pause</span>
         </button>
-        <button type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
-          <span>Mute</span>
+        <button id="btnMute" type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
+          <span className="unmutedLabel">Mute</span>
+          <span className="mutedLabel">Unmute</span>
         </button>
-        <button type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
+        <button id="btnHint" type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
           <span>Hint</span>
         </button>
 

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -21,6 +21,34 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-font-family-base: 'Assistant';
   --ifm-footer-background-color: #123550;
+  
+  /** 
+  * Set the mute and unmute button colors 
+  * Hide or show the button labels based on the mute state
+  */
+  .muted {
+    background-color: #123550;
+    color: #ebe4e4;
+    .mutedLabel {
+      display: inherit;
+    }
+    .unmutedLabel {
+      display: none;
+    }
+  }
+  .unmuted {
+    background-color: #0C7AC0;
+    .mutedLabel {
+      display: none;
+    }
+    .unmutedLabel {
+      display: inherit;
+    }
+  }
+  /** Hide the muted label by default */
+  .mutedLabel {
+    display: none;
+  }
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */


### PR DESCRIPTION
Updated the demo page to support audio mute through SR container. 

Note: This currently requires a demo update in order to function. 

If you want to test this out, you can pull the demo down from here: https://github.com/SpringRoll/springroll-io-demo-game/tree/feature/187839053-Game-Demo-Mute

Build and run the demo, and change the path of container by setting the URL to: 
`container.openPath('http://localhost:9090/');` in `src/components/GameDemo/index.tsx`

Ticket: https://www.pivotaltracker.com/story/show/187839053