### PR TITLE
Feature/187839050 - Game Demo Pause

### DIFF
--- a/src/components/GameDemo/index.tsx
+++ b/src/components/GameDemo/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, JSX } from 'react';
 import clsx from 'clsx';
 import styles from './styles.module.scss';
-import { Container, SoundPlugin } from 'springroll-container';
+import { Container, SoundPlugin, PausePlugin } from 'springroll-container';
 import Heading from '@theme/Heading';
 
 
@@ -16,7 +16,8 @@ export default function GameDemo(): JSX.Element {
       plugins: [
         new SoundPlugin({
           soundButtons: '#btnMute',
-        })
+        }),
+        new PausePlugin('#btnPause'),
       ]
     });
 
@@ -32,11 +33,12 @@ export default function GameDemo(): JSX.Element {
         </Heading>
         
         <button id="btnPause" type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
-          <span>Pause</span>
+          <span className="toggleOn">Pause</span>
+          <span className="toggleOff">Unpause</span>
         </button>
         <button id="btnMute" type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
-          <span className="unmutedLabel">Mute</span>
-          <span className="mutedLabel">Unmute</span>
+          <span className="toggleOn">Mute</span>
+          <span className="toggleOff">Unmute</span>
         </button>
         <button id="btnHint" type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
           <span>Hint</span>

--- a/src/components/GameDemo/index.tsx
+++ b/src/components/GameDemo/index.tsx
@@ -1,8 +1,9 @@
 import { useEffect, JSX } from 'react';
 import clsx from 'clsx';
 import styles from './styles.module.scss';
-import { Container } from 'springroll-container';
+import { Container, SoundPlugin } from 'springroll-container';
 import Heading from '@theme/Heading';
+
 
 /**
  * Game Demo Component - Creates a springroll container and loads the demo game into it. Referenced in docs/Examples/game.mdx
@@ -12,7 +13,11 @@ export default function GameDemo(): JSX.Element {
   // Instantiate the container and load the demo game after the component mounts  
   useEffect(() => {
     const container = new Container('#demo-game', {
-      plugins: []
+      plugins: [
+        new SoundPlugin({
+          soundButtons: '#btnMute',
+        })
+      ]
     });
 
     container.openPath('http://springroll.io/springroll-io-demo-game/');
@@ -26,13 +31,14 @@ export default function GameDemo(): JSX.Element {
           Game Options
         </Heading>
         
-        <button type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
+        <button id="btnPause" type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
           <span>Pause</span>
         </button>
-        <button type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
-          <span>Mute</span>
+        <button id="btnMute" type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
+          <span className="unmutedLabel">Mute</span>
+          <span className="mutedLabel">Unmute</span>
         </button>
-        <button type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
+        <button id="btnHint" type="button" className={clsx('button button--primary', styles.gameOptionButton)}>
           <span>Hint</span>
         </button>
 

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -21,6 +21,34 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-font-family-base: 'Assistant';
   --ifm-footer-background-color: #123550;
+  
+  /** 
+  * Set the mute and unmute button colors 
+  * Hide or show the button labels based on the mute state
+  */
+  .muted {
+    background-color: #123550;
+    color: #ebe4e4;
+    .mutedLabel {
+      display: inherit;
+    }
+    .unmutedLabel {
+      display: none;
+    }
+  }
+  .unmuted {
+    background-color: #0C7AC0;
+    .mutedLabel {
+      display: none;
+    }
+    .unmutedLabel {
+      display: inherit;
+    }
+  }
+  /** Hide the muted label by default */
+  .mutedLabel {
+    display: none;
+  }
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -26,22 +26,22 @@
   * Set the mute and unmute button colors 
   * Hide or show the button labels based on the mute state
   */
-  .muted {
+  .muted, .paused {
     background-color: #123550;
     color: #ebe4e4;
-    .mutedLabel {
+    .toggleOff {
       display: inherit;
     }
-    .unmutedLabel {
+    .toggleOn {
       display: none;
     }
   }
-  .unmuted {
+  .unmuted, .unpaused {
     background-color: #0C7AC0;
-    .mutedLabel {
+    .toggleOff {
       display: none;
     }
-    .unmutedLabel {
+    .toggleOn {
       display: inherit;
     }
   }


### PR DESCRIPTION
This PR adds the pause plugin and pause button functionality. I've also renamed the button label classes so they make sense on both pause and mute buttons.

In addition to that, I caught a console error with the usage of the `<p>` tag in `game.mdx`. There were nested `p` tags. I've changed it to `<span>` to prevent that. 

This PR is based on this branch: https://github.com/SpringRoll/springroll.io/tree/feature/187839053-Game-Demo-Mute

Ticket: https://www.pivotaltracker.com/story/show/187839050