### PR TITLE
bugfix/188226690 - Fix dead links

### DIFF
--- a/src/components/BellhopExample/index.tsx
+++ b/src/components/BellhopExample/index.tsx
@@ -65,7 +65,7 @@ bellhop.on('clearMessages', () => {
     <section className='container'>
       <div className='row'>
         <div className={clsx('col', styles.bellhop_gameContainer)}>
-          <iframe id="demo-game" className={styles.bellhop_iframe} src='/BellHopExampleChild/'></iframe>
+          <iframe id="demo-game" className={styles.bellhop_iframe} src='/BellHopExampleChild/index.html'></iframe>
         </div>
         <div className={clsx('col', styles.bellhop_controls)}>
           <button id='sendButton' className="button button--primary" onClick={sendPostMessage}>Send Message</button>

--- a/src/components/IndexedDB/index.tsx
+++ b/src/components/IndexedDB/index.tsx
@@ -49,7 +49,7 @@ export default function IndexedDBExample(): JSX.Element {
 
             containerRef.current = container;
 
-            container.openPath('/idbExample');
+            container.openPath('/idbExample/index.html');
 
             // Setup event listeners
             events.forEach(event => {

--- a/static/BellHopExampleChild/index.html
+++ b/static/BellHopExampleChild/index.html
@@ -23,7 +23,7 @@
   <div id="frame">
     <ul id="messageList"></ul>
   </div>
-  <script src="./bellhop-umd.js"></script>
+  <script src="./BellHopExampleChild/bellhop-umd.js"></script>
   <script type="module">
     const bellhop = new window.Bellhop();
     


### PR DESCRIPTION
Updated iframe paths to fix issues on the dev site. They're now using an explicit `index.html` file. 

Also changed the path to `bellhop-umd.js` to fix deployed versions of the Bellhop example. Paths work differently when serving builds versus using the local dev server (running `npm run serve` vs `npm run start`). `./` resolves to the site root instead of the relative folder root as it seems to on the dev server. This fix still works on the dev server though.

Ticket: https://www.pivotaltracker.com/story/show/188226690