### PR TITLE
bugfix/188226690 - Updating JS file paths

### DIFF
--- a/static/BellHopExampleChild/index.html
+++ b/static/BellHopExampleChild/index.html
@@ -23,7 +23,7 @@
   <div id="frame">
     <ul id="messageList"></ul>
   </div>
-  <script src="./BellHopExampleChild/bellhop-umd.js"></script>
+  <script src="/BellHopExampleChild/bellhop-umd.js"></script>
   <script type="module">
     const bellhop = new window.Bellhop();
     

--- a/static/idbExample/index.html
+++ b/static/idbExample/index.html
@@ -174,7 +174,7 @@
     </div>
   </div>
 
-  <script src="./idbExample/SpringRoll-umd.js"></script>
+  <script src="/idbExample/SpringRoll-umd.js"></script>
   <script type="module">
 
     const testApp = new springroll.Application({


### PR DESCRIPTION
Changing paths to JS files in Bellhop and Indexed DB examples because they're breaking on the dev site. Iframes are showing up, but the paths to JS files are wrong. This should fix that issue.

Ticket: https://www.pivotaltracker.com/story/show/188226690