### PR TITLE
Fixing the prebuild for games

### DIFF
--- a/scripts/clone-demo-game.sh
+++ b/scripts/clone-demo-game.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Create the folder where we'll drop the demo game contents
-rm -rf public/springroll-io-demo-game
-mkdir public/springroll-io-demo-game
+rm -rf build/springroll-io-demo-game
+mkdir -p build/springroll-io-demo-game
 
 # Clone down the demo game
 rm -rf springroll-io-demo-game
 git clone --depth=1 https://github.com/SpringRoll/springroll-io-demo-game.git
-cp -R springroll-io-demo-game/docs/* public/springroll-io-demo-game
+cp -R springroll-io-demo-game/docs/* build/springroll-io-demo-game
 rm -rf springroll-io-demo-game


### PR DESCRIPTION
Looks like my copy command was dependent on a `public` folder existing. This change circumvents that and just copies directly to build (the final spot it'll need to be anyways).