### PR TITLE
Fixing/improving build script

### DIFF
--- a/scripts/clone-demo-game.sh
+++ b/scripts/clone-demo-game.sh
@@ -2,12 +2,15 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+CLONE_DIRECTORY="springroll-io-demo-game"
+TARGET_DIRECTORY="static/springroll-io-demo-game"
+
 # Create the folder where we'll drop the demo game contents
-rm -rf build/springroll-io-demo-game
-mkdir -p build/springroll-io-demo-game
+rm -rf "$TARGET_DIRECTORY"
+mkdir -p "$TARGET_DIRECTORY"
 
 # Clone down the demo game
-rm -rf springroll-io-demo-game
-git clone --depth=1 https://github.com/SpringRoll/springroll-io-demo-game.git
-cp -R springroll-io-demo-game/docs/* build/springroll-io-demo-game
-rm -rf springroll-io-demo-game
+rm -rf "$CLONE_DIRECTORY"
+git clone --depth=1 https://github.com/SpringRoll/springroll-io-demo-game.git "$CLONE_DIRECTORY"
+cp -R "$CLONE_DIRECTORY"/docs/* "$TARGET_DIRECTORY"
+rm -rf "$CLONE_DIRECTORY"


### PR DESCRIPTION
I had misread a build failure and had assumed that the static directory had been removed. It was actually the public directory as part of the docusaurus migration. As a result, I had updated this build script to instead build directly into the build/ folder instead of static. However, the lingering copy of the code in static was _overwriting_ the latest build. So, I've re-updated this script to copy back into static which is loading the latest copy of the game now. Moreover, I updated the script to DRY up some things and make it clearer what the script is doing.